### PR TITLE
A few fixes

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/game/MappingConfigurationImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/game/MappingConfigurationImpl.java
@@ -226,7 +226,7 @@ public class MappingConfigurationImpl implements MappingConfiguration {
 				if (getTargetNamespace().equals("official")) {
 					Log.warn(LogCategory.MAPPINGS, "Continuing without mappings because target namespace is 'official'");
 				} else {
-					throw new IllegalStateException("Requested target namespace %s not loaded. To continue without mappings, " +
+					throw new IllegalStateException("Requested target namespace " + targetNamespace + " not loaded. To continue without mappings, " +
 							"set the target namespace to 'official' with -D" + SystemProperties.TARGET_NAMESPACE + "=official");
 				}
 			}

--- a/src/main/java/org/quiltmc/loader/impl/transformer/KotlinMetadataRemapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/KotlinMetadataRemapper.java
@@ -43,35 +43,30 @@ public class KotlinMetadataRemapper extends ClassVisitor {
 	@Override
 	public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
 		if (descriptor.equals("Lkotlin/Metadata;")) {
-			return new AnnotationNode(QuiltLoaderImpl.ASM_VERSION, descriptor) {
+			return new AnnotationVisitor(api, super.visitAnnotation(descriptor, visible)) {
 				@Override
-				public void visitEnd() {
-					super.visitEnd();
+				public AnnotationVisitor visitArray(String name) {
+					if ("d2".equals(name)) {
+						return new AnnotationVisitor(api, super.visitArray(name)) {
+							@Override
+							public void visit(String name, Object value) {
+								if (value instanceof String) {
+									String candidate = (String) value;
+									if (candidate.startsWith("(")) {
+										candidate = remapper.mapMethodDesc(candidate);
+									} else if (candidate.startsWith("L")) { // this could technically catch strays but it should just not do anything
+										candidate = remapper.mapDesc(candidate);
+									} else if (candidate.startsWith("class_") || candidate.contains("/")) { // must go last to not accidentally catch descriptors
+										candidate = remapper.map(candidate);
+									} // else hope nothing goes wrong
+									value = candidate;
+								}
 
-					List<String> data = null;
-					Iterator<Object> iter = this.values.iterator();
-					while (iter.hasNext()) {
-						if (iter.next().equals("d2")) {
-							//noinspection unchecked
-							data = (List<String>) iter.next();
-							break;
-						}
+								super.visit(name, value);
+							}
+						};
 					}
-					if (data == null) {
-						return;
-					}
-					for (int i = 0; i < data.size(); i++) {
-						String candidate = data.get(i);
-						if (candidate.startsWith("(")) {
-							candidate = remapper.mapMethodDesc(candidate);
-						} else if (candidate.startsWith("L")) { // this could technically catch strays but it should just not do anything
-							candidate = remapper.mapDesc(candidate);
-						} else if (candidate.startsWith("class_") || candidate.contains("/")) { // must go last to not accidentally catch descriptors
-							candidate = remapper.map(candidate);
-						} // else hope nothing goes wrong
-						data.set(i, candidate);
-					}
-
+					return super.visitArray(name);
 				}
 			};
 		}

--- a/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java
@@ -27,6 +27,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -68,8 +69,9 @@ final class RuntimeModRemapper {
 	private static final String REMAP_TYPE_MANIFEST_KEY = "Fabric-Loom-Mixin-Remap-Type";
 	private static final String REMAP_TYPE_STATIC = "static";
 
-	public static void remap(TransformCache cache) {
-		QuiltLauncher launcher = QuiltLauncherBase.getLauncher();
+	private final Set<ModLoadOption> modsToRemap = new LinkedHashSet<>();
+
+	RuntimeModRemapper(List<ModLoadOption> mods) {
 		MappingConfiguration mappingConfiguration = QuiltLauncherBase.getLauncher().getMappingConfiguration();
 
 		if (mappingConfiguration == null) {
@@ -84,27 +86,32 @@ final class RuntimeModRemapper {
 			return;
 		} else if (!mappingConfiguration.getNamespaces().contains("intermediary")) {
 			Log.warn(LogCategory.MOD_REMAP, "Not remapping mods because intermediary is missing!");
+			return;
 		}
 
-		List<ModLoadOption> modsToRemap = cache.getModsInCache().stream()
-				.filter(modLoadOption -> {
-					String namespace = modLoadOption.namespaceMappingFrom();
-					if ("mojang".equals(namespace)) {
-						throw new UnsupportedOperationException("Cannot remap mojang mods to another environment!");
-					}
-					return namespace != null;
-				})
-				.collect(Collectors.toList());
+		for (ModLoadOption mod : mods) {
+			String namespace = mod.namespaceMappingFrom();
+			if ("mojang".equals(namespace)) {
+				throw new UnsupportedOperationException("Cannot remap mojang mods to another environment!");
+			}
+			if (namespace != null) {
+				modsToRemap.add(mod);
+			}
+		}
+	}
+
+	public boolean doesModNeedRemapping(ModLoadOption mod) {
+		return modsToRemap.contains(mod);
+	}
+
+	public void remap(TransformCache cache) {
+		QuiltLauncher launcher = QuiltLauncherBase.getLauncher();
+		MappingConfiguration mappingConfiguration = QuiltLauncherBase.getLauncher().getMappingConfiguration();
 
 		if (modsToRemap.isEmpty()) {
 			return;
 		}
 		Set<InputTag> remapMixins = new HashSet<>();
-
-		QuiltUnifiedFileSystem fs = new QuiltUnifiedFileSystem("transform-cache-remapping", false);
-
-
-
 
 		TinyRemapper remapper = TinyRemapper.newRemapper()
 				.withMappings(TinyUtils.createMappingProvider(mappingConfiguration.getMappings(), "intermediary", mappingConfiguration.getTargetNamespace()))
@@ -112,6 +119,15 @@ final class RuntimeModRemapper {
 				.extension(new MixinExtension(remapMixins::contains))
 				.extraPreApplyVisitor(KotlinMetadataRemapper::new)
 				.build();
+
+		try {
+			remap0(cache, launcher, remapMixins, remapper);
+		} finally {
+			remapper.finish();
+		}
+	}
+
+	private void remap0(TransformCache cache, QuiltLauncher launcher, Set<InputTag> remapMixins, TinyRemapper remapper) {
 
 		if (launcher.isDevelopment()) {
 			try {
@@ -123,6 +139,8 @@ final class RuntimeModRemapper {
 			remapper.readClassPathAsync(launcher.getClassPath().toArray(new Path[0]));
 			remapper.readClassPathAsync(QuiltLoaderImpl.INSTANCE.getGameProvider().getGameJars("intermediary").toArray(new Path[0]));
 		}
+
+		QuiltUnifiedFileSystem fs = new QuiltUnifiedFileSystem("transform-cache-remapping", false);
 
 		try {
 			Map<ModLoadOption, RemapInfo> infoMap = new HashMap<>();
@@ -184,7 +202,6 @@ final class RuntimeModRemapper {
 				}
 			}
 
-			remapper.finish();
 			fs.close();
 
 			for (ModLoadOption mod : modsToRemap) {
@@ -199,7 +216,6 @@ final class RuntimeModRemapper {
 			}
 
 		} catch (IOException e) {
-			remapper.finish();
 			throw new RuntimeException("Failed to remap mods", e);
 		}
 	}

--- a/src/main/java/org/quiltmc/loader/impl/transformer/TransformCache.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/TransformCache.java
@@ -67,6 +67,8 @@ class TransformCache {
 		this.allMods = orderedMods;
 		this.modsInCache = orderedMods.stream().filter(mod -> mod.needsTransforming() && !QuiltLoaderImpl.MOD_ID.equals(mod.id())).collect(Collectors.toList());
 
+		RuntimeModRemapper remapper = new RuntimeModRemapper(modsInCache);
+
 		for (ModLoadOption mod : this.modsInCache) {
 			Path modSrc = mod.createTransformRoot();
 			Path modDst = root.resolve(mod.id());
@@ -124,7 +126,7 @@ class TransformCache {
 					}
 
 					// copy classes for mods which don't need remapped
-					if (mod.namespaceMappingFrom() == null) {
+					if (!remapper.doesModNeedRemapping(mod)) {
 						try (Stream<Path> stream = Files.walk(modSrc)) {
 							stream
 								.filter(FasterFiles::isRegularFile)
@@ -132,7 +134,7 @@ class TransformCache {
 								.forEach(path -> copyFile(path, modSrc, modDst));
 						}
 					}
-				} else if (mod.namespaceMappingFrom() != null) {
+				} else if (remapper.doesModNeedRemapping(mod)) {
 					// Copy everything that isn't a class file, since those get remapped
 					try (Stream<Path> stream = Files.walk(modSrc)) {
 						stream
@@ -153,7 +155,7 @@ class TransformCache {
 			}
 		}
 		// Populate mods that need remapped
-		RuntimeModRemapper.remap(this);
+		remapper.remap(this);
 		for (ModLoadOption orderedMod : this.modsInCache) {
 			modRoots.put(orderedMod, root.resolve(orderedMod.id() + "/"));
 		}


### PR DESCRIPTION
- Fix MappingConfigurationImpl's "missing namespace" exception not including the target namespace in the error message
- Fix KotlinMetadataRemapper discarding the metadata annotation
- Slightly optimise and simplify the logic in KotlinMetadataRemapper by using AnnotationVisitor instead of AnnotationNode
- Fix a JVM hang when the remapper throws something that isn't an IOException after creating the TinyRemapper by wrapping it's entire lifetime in a try...finally { remapper.finish(); }
	- This ensures the non-daemon thread pool is stopped.
- Refactor how RuntimeModRemapper is used by TransformCache - the remapper is now an initialised object, and stores the "modsToRemap"
	- This allows the remapping logic to be fully stored in the remapper, which ensures the mod file copy step will always copy mod class files if the remapper isn't going to. (Previously the cache assumed that if a mod had a "namespaceMappingFrom" then it would be remapped, however this is no longer the case with the checks at the start of RuntimeModRemapper)